### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,11 +12,11 @@ SuperChrono	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-restart KEYWORD2
-stop KEYWORD2
-resume KEYWORD2
-add KEYWORD2
-running KEYWORD2
+restart	KEYWORD2
+stop	KEYWORD2
+resume	KEYWORD2
+add	KEYWORD2
+running	KEYWORD2
 elapsed	KEYWORD2
 passed	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords